### PR TITLE
Monkey patch Tap.cli to accept synonymous args

### DIFF
--- a/tap_aircall/_tap.py
+++ b/tap_aircall/_tap.py
@@ -1,0 +1,145 @@
+from typing import List, Callable, Tuple
+import click
+
+from pathlib import Path
+
+from singer_sdk import Tap
+from singer_sdk.helpers._classproperty import classproperty
+from singer_sdk.tap_base import CliTestOptionValue
+from singer_sdk.cli import common_options
+
+class _Tap(Tap):
+    """
+    Monkeypatches the Tap.cli to accept -c arg as the same as --config
+    If both are provided, --config arg is accepted first
+    """
+    @classproperty
+    def cli(cls) -> Callable:
+        """Execute standard CLI handler for taps.
+
+        Returns:
+            A callable CLI object.
+        """
+
+        @common_options.PLUGIN_VERSION
+        @common_options.PLUGIN_ABOUT
+        @common_options.PLUGIN_ABOUT_FORMAT
+        @common_options.PLUGIN_CONFIG
+        @click.option(
+            "-c",
+            multiple=True,
+            help="Configuration file location or 'ENV' to use environment variables.",
+            type=click.STRING,
+            default=(),
+        )
+        @click.option(
+            "--discover",
+            is_flag=True,
+            help="Run the tap in discovery mode.",
+        )
+        @click.option(
+            "--test",
+            is_flag=False,
+            flag_value=CliTestOptionValue.All.value,
+            default=CliTestOptionValue.Disabled,
+            help=(
+                "Use --test to sync a single record for each stream. "
+                + "Use --test=schema to test schema output without syncing "
+                + "records."
+            ),
+        )
+        @click.option(
+            "--catalog",
+            help="Use a Singer catalog file with the tap.",
+            type=click.Path(),
+        )
+        @click.option(
+            "--state",
+            help="Use a bookmarks file for incremental replication.",
+            type=click.Path(),
+        )
+        @click.command(
+            help="Execute the Singer tap.",
+            context_settings={"help_option_names": ["--help"]},
+        )
+        def cli(
+            version: bool = False,
+            about: bool = False,
+            discover: bool = False,
+            test: CliTestOptionValue = CliTestOptionValue.Disabled,
+            config: Tuple[str, ...] = (),
+            c: Tuple[str, ...] = (),
+            state: str = None,
+            catalog: str = None,
+            format: str = None,
+        ) -> None:
+            """Handle command line execution.
+
+            Args:
+                version: Display the package version.
+                about: Display package metadata and settings.
+                discover: Run the tap in discovery mode.
+                test: Test connectivity by syncing a single record and exiting.
+                format: Specify output style for `--about`.
+                config: Configuration file location or 'ENV' to use environment
+                    variables. Accepts multiple inputs as a tuple.
+                catalog: Use a Singer catalog file with the tap.",
+                state: Use a bookmarks file for incremental replication.
+
+            Raises:
+                FileNotFoundError: If the config file does not exist.
+            """
+            if version:
+                cls.print_version()
+                return
+
+            config_to_use = config or c
+
+            if not about:
+                cls.print_version(print_fn=cls.logger.info)
+            else:
+                cls.print_about(format=format)
+                return
+
+            validate_config: bool = True
+            if discover:
+                # Don't abort on validation failures
+                validate_config = False
+
+            parse_env_config = False
+            config_files: List[PurePath] = []
+            for config_path in config_to_use:
+                if config_path == "ENV":
+                    # Allow parse from env vars:
+                    parse_env_config = True
+                    continue
+
+                # Validate config file paths before adding to list
+                if not Path(config_path).is_file():
+                    raise FileNotFoundError(
+                        f"Could not locate config file at '{config_path}'."
+                        "Please check that the file exists."
+                    )
+
+                config_files.append(Path(config_path))
+
+            tap = cls(  # type: ignore  # Ignore 'type not callable'
+                config=config_files or None,
+                state=state,
+                catalog=catalog,
+                parse_env_config=parse_env_config,
+                validate_config=validate_config,
+            )
+
+            if discover:
+                tap.run_discovery()
+                if test == CliTestOptionValue.All.value:
+                    tap.run_connection_test()
+            elif test == CliTestOptionValue.All.value:
+                tap.run_connection_test()
+            elif test == CliTestOptionValue.Schema.value:
+                tap.write_schemas()
+            else:
+                tap.sync_all()
+
+        return cli

--- a/tap_aircall/_tap.py
+++ b/tap_aircall/_tap.py
@@ -8,10 +8,52 @@ from singer_sdk.helpers._classproperty import classproperty
 from singer_sdk.tap_base import CliTestOptionValue
 from singer_sdk.cli import common_options
 
+CONFIG_OPTION = click.option(
+    "-c",
+    multiple=True,
+    help="Configuration file location or 'ENV' to use environment variables.",
+    type=click.STRING,
+    default=(),
+)
+DISCOVER_OPTION = click.option(
+    "--discover",
+    is_flag=True,
+    help="Run the tap in discovery mode.",
+)
+TEST_OPTION = click.option(
+    "--test",
+    is_flag=False,
+    flag_value=CliTestOptionValue.All.value,
+    default=CliTestOptionValue.Disabled,
+    help=(
+        "Use --test to sync a single record for each stream. "
+        + "Use --test=schema to test schema output without syncing "
+        + "records."
+    ),
+)
+CATALOG_OPTION = click.option(
+    "--catalog",
+    help="Use a Singer catalog file with the tap.",
+    type=click.Path(),
+)
+PROPERTIES_OPTION = click.option(
+    "--properties",
+    help="Use a Singer catalog file with the tap.",
+    type=click.Path(),
+)
+STATE_OPTION = click.option(
+    "--state",
+    help="Use a bookmarks file for incremental replication.",
+    type=click.Path(),
+)
+
 class _Tap(Tap):
     """
-    Monkeypatches the Tap.cli to accept -c arg as the same as --config
-    If both are provided, --config arg is accepted first
+    Monkeypatches the Tap.cli to accept:
+    1. -c arg as the same as --config
+        - If both are provided, --config arg is accepted first
+    2. --properties arg as the same as --catalog, but deprecated
+        - If both are provided, --catalog arg is accepted first
     """
     @classproperty
     def cli(cls) -> Callable:
@@ -25,39 +67,12 @@ class _Tap(Tap):
         @common_options.PLUGIN_ABOUT
         @common_options.PLUGIN_ABOUT_FORMAT
         @common_options.PLUGIN_CONFIG
-        @click.option(
-            "-c",
-            multiple=True,
-            help="Configuration file location or 'ENV' to use environment variables.",
-            type=click.STRING,
-            default=(),
-        )
-        @click.option(
-            "--discover",
-            is_flag=True,
-            help="Run the tap in discovery mode.",
-        )
-        @click.option(
-            "--test",
-            is_flag=False,
-            flag_value=CliTestOptionValue.All.value,
-            default=CliTestOptionValue.Disabled,
-            help=(
-                "Use --test to sync a single record for each stream. "
-                + "Use --test=schema to test schema output without syncing "
-                + "records."
-            ),
-        )
-        @click.option(
-            "--catalog",
-            help="Use a Singer catalog file with the tap.",
-            type=click.Path(),
-        )
-        @click.option(
-            "--state",
-            help="Use a bookmarks file for incremental replication.",
-            type=click.Path(),
-        )
+        @CONFIG_OPTION
+        @DISCOVER_OPTION
+        @TEST_OPTION
+        @CATALOG_OPTION
+        @PROPERTIES_OPTION
+        @STATE_OPTION
         @click.command(
             help="Execute the Singer tap.",
             context_settings={"help_option_names": ["--help"]},
@@ -71,6 +86,7 @@ class _Tap(Tap):
             c: Tuple[str, ...] = (),
             state: str = None,
             catalog: str = None,
+            properties: str = None,
             format: str = None,
         ) -> None:
             """Handle command line execution.
@@ -83,7 +99,9 @@ class _Tap(Tap):
                 format: Specify output style for `--about`.
                 config: Configuration file location or 'ENV' to use environment
                     variables. Accepts multiple inputs as a tuple.
-                catalog: Use a Singer catalog file with the tap.",
+                c: Same as `config`
+                catalog: Use a Singer catalog file with the tap.
+                properties: Same as, but deprecated in favour of `catalog`.
                 state: Use a bookmarks file for incremental replication.
 
             Raises:
@@ -126,7 +144,7 @@ class _Tap(Tap):
             tap = cls(  # type: ignore  # Ignore 'type not callable'
                 config=config_files or None,
                 state=state,
-                catalog=catalog,
+                catalog=catalog or properties,
                 parse_env_config=parse_env_config,
                 validate_config=validate_config,
             )

--- a/tap_aircall/tap.py
+++ b/tap_aircall/tap.py
@@ -9,6 +9,7 @@ from tap_aircall.streams import (
     CallsStream,
     UsersStream,
 )
+from tap_aircall._tap import _Tap
 # TODO: Compile a list of custom stream types here
 #       OR rewrite discover_streams() below with your custom logic.
 STREAM_TYPES = [
@@ -17,7 +18,7 @@ STREAM_TYPES = [
 ]
 
 
-class Tapaircall(Tap):
+class Tapaircall(_Tap):
     """aircall tap class."""
     name = "tap-aircall"
 


### PR DESCRIPTION
We pin the version, so I'm not too concerned about this. However if we ever do bump up `singer_sdk`, it might be necessary to update this.