### PR TITLE
Fuj 4262v1.0

### DIFF
--- a/tap_aircall/client.py
+++ b/tap_aircall/client.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, Iterable, Callable, Generator
 from urllib.parse import urlparse, parse_qs
 
 import requests
-import sys
+import time
 import backoff
 
 from datetime import datetime
@@ -77,21 +77,24 @@ class aircallStream(RESTStream):
         if self.replication_key:
             params["order"] = "asc"
             # params["order_by"] = self.replication_key
-        starting_time = self.get_starting_timestamp(context) if type(context) is datetime else None
-        if starting_time:
-            params["from"] = str(round(starting_time.timestamp()))
+        
+        #FUJ-4262, Aircall tap for Wine Enthusiast is not fetching data beyond 3/20
+        
+        #starting_time = self.get_starting_timestamp(context) if type(context) is datetime else None
+        
+        # Aircall API expects Epoch or Unix Timestamp vs ISO datetime
+        # get replication key from bookmark
+        
+        starting_time = self.get_starting_timestamp(context)
+        starting_unix_time = starting_time.timestamp()
+        
+        if starting_unix_time:
+            params["from"] = starting_unix_time
+        else:
+            #Unix Timestamp
+            params["from"] = time.time()
 
         return params
-
-    def prepare_request_payload(
-            self, context: Optional[dict], next_page_token: Optional[Any]
-    ) -> Optional[dict]:
-        """Prepare the data payload for the REST API request.
-
-        By default, no payload will be sent (return None).
-        """
-        # TODO: Delete this method if no payload is required. (Most REST APIs.)
-        return None
 
     def parse_response(self, response: requests.Response) -> Iterable[dict]:
         """Parse the response and return an iterator of result rows."""

--- a/tap_aircall/client.py
+++ b/tap_aircall/client.py
@@ -97,7 +97,7 @@ class aircallStream(RESTStream):
         return params
     
     def prepare_request_payload(
-        self, context: Optional[dict], next_page_token: Optional[Any]
+            self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Optional[dict]:
         """Prepare the data payload for the REST API request.
         By default, no payload will be sent (return None).

--- a/tap_aircall/client.py
+++ b/tap_aircall/client.py
@@ -95,6 +95,15 @@ class aircallStream(RESTStream):
             params["from"] = time.time()
 
         return params
+    
+    def prepare_request_payload(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Optional[dict]:
+        """Prepare the data payload for the REST API request.
+        By default, no payload will be sent (return None).
+        """
+        # TODO: Delete this method if no payload is required. (Most REST APIs.)
+        return None
 
     def parse_response(self, response: requests.Response) -> Iterable[dict]:
         """Parse the response and return an iterator of result rows."""

--- a/tap_aircall/streams.py
+++ b/tap_aircall/streams.py
@@ -26,7 +26,12 @@ class CallsStream(aircallStream):
     name = "calls"
     path = "v1/calls"
     primary_keys = ["id"]
-    replication_key = "id"
+    
+    #FUJ-4262, Aircall tap for Wine Enthusiast is not fetching data beyond 3/20
+    # Changed replication_key to look at started date/time vs call id
+    #replication_key = "id"
+    replication_key = "started_at"
+    
     schema = call_properties.to_dict()
     records_jsonpath = "$.calls[*]"  # Or override `parse_response`.
 

--- a/tap_aircall/streams.py
+++ b/tap_aircall/streams.py
@@ -28,7 +28,7 @@ class CallsStream(aircallStream):
     primary_keys = ["id"]
     
     #FUJ-4262, Aircall tap for Wine Enthusiast is not fetching data beyond 3/20
-    # Changed replication_key to look at started date/time vs call id
+    # Changed replication_key to look at call start date/time vs call id
     #replication_key = "id"
     replication_key = "started_at"
     


### PR DESCRIPTION
The code has been updated to

1) Use the 'started_at' key for the CallStream bookmark
2) Convert ISO datetime stamp to UNIX datetime stamp as expected by Aircall API