### PR TITLE
partition requests st if the #of items in a certain range is <10k

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='tap-aircall',
-      version='0.0.7',
+      version='0.1.4',
       description='Singer.io tap for extracting data from the Aircall API',
       author='Pathlight',
       url='https://www.pathlight.com',

--- a/tap_aircall/client.py
+++ b/tap_aircall/client.py
@@ -1,5 +1,6 @@
 """REST client handling, including aircallStream base class."""
 
+import time
 from pathlib import Path
 from typing import Any, Dict, Optional, Iterable, Callable, Generator
 from urllib.parse import urlparse, parse_qs
@@ -78,7 +79,15 @@ class aircallStream(RESTStream):
         if self.replication_key:
             params["order"] = "asc"
 
-        params.update(context)  # If there's a partitions property, update it with the context
+        starting_time = self.get_starting_timestamp(context)
+        starting_unix_time = starting_time.timestamp()
+
+        if starting_unix_time:
+            params["from"] = starting_unix_time
+        else:
+            params["from"] = time.time()  # Unix timestamp
+
+        params.update(context)  # If there are partitions, update it with the context
         return params
 
     def parse_response(self, response: requests.Response) -> Iterable[dict]:

--- a/tap_aircall/client.py
+++ b/tap_aircall/client.py
@@ -5,17 +5,14 @@ from typing import Any, Dict, Optional, Iterable, Callable, Generator
 from urllib.parse import urlparse, parse_qs
 
 import requests
-import time
 import backoff
 
 from datetime import datetime
 from singer_sdk.authenticators import BasicAuthenticator
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 from singer_sdk.streams import RESTStream
-from singer_sdk.exceptions import RetriableAPIError
 
 SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
-
 
 class aircallStream(RESTStream):
     """aircall stream class."""
@@ -51,9 +48,10 @@ class aircallStream(RESTStream):
         # TODO: If pagination is required, return a token which can be used to get the
         #       next page. If this is the final page, return "None" to end the
         #       pagination loop.
+        json_response = response.json()
         if self.next_page_token_jsonpath:
             all_matches = extract_jsonpath(
-                self.next_page_token_jsonpath, response.json()
+                self.next_page_token_jsonpath, json_response
             )
             first_match = next(iter(all_matches), None)
             next_page_token = first_match
@@ -66,44 +64,22 @@ class aircallStream(RESTStream):
             self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization."""
-        params: dict = {}
+        if not context:
+            context = {}
+
+        params: dict = {"per_page": 50}
         if next_page_token:
             # format next_page_token: "https://api.aircall.io/v1/calls?page=2&per_page=20"
             # page & per_page require int params
             # extract query from next_page_token string
             next_page_token_query: Dict = parse_qs(urlparse(next_page_token).query)
-            params["page"] = int(next_page_token_query.get('page', ['1'])[0])  # Default si 1
-            params["per_page"] = int(next_page_token_query.get('per_page', ['20'])[0])  # Default is 20
+            params["page"] = int(next_page_token_query.get('page', ['1'])[0])  # Default is 1
+            params["per_page"] = int(next_page_token_query.get('per_page', ['50'])[0])  # Default is is 20, but use 50
         if self.replication_key:
             params["order"] = "asc"
-            # params["order_by"] = self.replication_key
-        
-        #FUJ-4262, Aircall tap for Wine Enthusiast is not fetching data beyond 3/20
-        
-        #starting_time = self.get_starting_timestamp(context) if type(context) is datetime else None
-        
-        # Aircall API expects Epoch or Unix Timestamp vs ISO datetime
-        # get replication key from bookmark
-        
-        starting_time = self.get_starting_timestamp(context)
-        starting_unix_time = starting_time.timestamp()
-        
-        if starting_unix_time:
-            params["from"] = starting_unix_time
-        else:
-            #Unix Timestamp
-            params["from"] = time.time()
 
+        params.update(context)  # If there's a partitions property, update it with the context
         return params
-    
-    def prepare_request_payload(
-            self, context: Optional[dict], next_page_token: Optional[Any]
-    ) -> Optional[dict]:
-        """Prepare the data payload for the REST API request.
-        By default, no payload will be sent (return None).
-        """
-        # TODO: Delete this method if no payload is required. (Most REST APIs.)
-        return None
 
     def parse_response(self, response: requests.Response) -> Iterable[dict]:
         """Parse the response and return an iterator of result rows."""
@@ -121,7 +97,7 @@ class aircallStream(RESTStream):
             if key in row and row.get(key):
                 row[key] = datetime.fromtimestamp(row.get(key))
         return row
-    
+
     """
     # This code-block is not required when backoff_wait_generator code-block is active
     def validate_response(self, response: requests.Response) -> None:
@@ -135,13 +111,11 @@ class aircallStream(RESTStream):
             else:
                 raise e
     """
-    
+
     #https://sdk.meltano.com/en/latest/code_samples.html#custom-backoff
     #FUJ-4120, introducing custom backoff for Aircall taps
-    
+
     #https://developer.aircall.io/tutorials/logging-calls/#:~:text=Aircall%20Public%20API%20is%20rate,will%20be%20blocked%20by%20Aircall.
     #Aircall allows 60 requests per minute, generating a wait time of 90 seconds to avoid error caused by RateLimit exception
     def backoff_wait_generator(max_time: int) -> Callable[..., Generator[int, Any, None]]:
         return backoff.constant(interval=90)
-    
-    

--- a/tap_aircall/streams.py
+++ b/tap_aircall/streams.py
@@ -1,9 +1,36 @@
 """Stream type classes for tap-aircall."""
 
-from typing import Optional
+from typing import Optional, List, Dict
 
 from tap_aircall.client import aircallStream
 from .schemas import user_properties, call_properties
+
+from datetime import datetime, timedelta
+from dateutil.parser import parse as parse_datetime
+
+
+def get_stream_partitions_range(config: dict) -> List[Dict[str, float]]:
+    if "start_date" not in config:
+        return []
+
+    now = datetime.now()
+    try:
+        start_date_as_dt = parse_datetime(config["start_date"])
+    except Exception:
+        start_date_as_dt = now - timedelta(days=30)  # Default to the last 30 days
+
+    interval_hours = config.get("interval_hours") or 24
+    delta = timedelta(hours=interval_hours)
+    current_datetime = start_date_as_dt
+    datetimes = []
+
+    while current_datetime <= now:
+        datetimes.append({
+            'from': current_datetime.timestamp(),
+            'to': (current_datetime + delta).timestamp()
+        })
+        current_datetime += delta
+    return datetimes
 
 
 class UsersStream(aircallStream):
@@ -26,14 +53,15 @@ class CallsStream(aircallStream):
     name = "calls"
     path = "v1/calls"
     primary_keys = ["id"]
-    
-    #FUJ-4262, Aircall tap for Wine Enthusiast is not fetching data beyond 3/20
-    # Changed replication_key to look at call start date/time vs call id
-    #replication_key = "id"
     replication_key = "started_at"
-    
     schema = call_properties.to_dict()
     records_jsonpath = "$.calls[*]"  # Or override `parse_response`.
+
+    @property
+    def partitions(self):
+        # Since there's a limit of 10k results in a single request,
+        # split up the requests so that we get the full amount
+        return get_stream_partitions_range(self.config)
 
 class UserStream(aircallStream):
     """Define custom stream."""


### PR DESCRIPTION
https://pathlighthq.atlassian.net/browse/FUJ-5333

basically we're full syncing for x days. In the last x days, it's possible that the num of calls is > 10k for a given "from" param. When that's true, everything after it doesn't get synced because there's no next page token.

I tried adjusting the get_next_page_token to return a new page link, using the last record's started_at time as the new "from" time, but singer is wack and doesn't respect it.

https://developer.aircall.io/api-references/#pagination

https://developer.aircall.io/api-references/#list-all-calls

Side effect is that the bookmarks are also wack. Idk what effect it has on bookmark reading:

```json5
{
    "bookmarks": {
        "calls": {
            "partitions": [
                { "context": { "from": 1691985600.0, "to": 1692000000.0 } },
                {
                    "context": { "from": 1692000000.0, "to": 1692014400.0 },
                    "replication_key": "started_at",
                    "replication_key_value": "2023-08-14T07:58:24+00:00"
                },
                ...
                {
                    "context": { "from": 1692388800.0, "to": 1692403200.0 },
                    "replication_key": "started_at",
                    "replication_key_value": "2023-08-18T19:50:20+00:00"
                },
                {
                    "context": { "from": 1692403200.0, "to": 1692417600.0 },
                    "replication_key": "started_at",
                    "replication_key_value": "2023-08-18T20:53:20+00:00"
                }
            ]
        }
    }
}

```